### PR TITLE
ページネーションの追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem 'kaminari'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,18 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     logger (1.6.5)
     loofah (2.24.0)
       crass (~> 1.0.2)
@@ -257,6 +269,7 @@ DEPENDENCIES
   error_highlight (>= 0.4.0)
   importmap-rails
   jbuilder
+  kaminari
   puma (>= 5.0)
   rails (~> 7.1.5, >= 7.1.5.1)
   selenium-webdriver

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,6 +1,6 @@
 class ArticlesController < ApplicationController
   def index
-    @articles = Article.all
+    @articles = Article.all.page(params[:page]).per(5)
   end
 
   def show

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -7,4 +7,6 @@
   <% end %>
 </ul>
 
+<%= paginate @articles %>
+
 <%= link_to "新規作成", new_article_path %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,7 @@ module RailsBlog
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "..."


### PR DESCRIPTION
### 概要
- ページネーションを追加しました。
 
### 変更内容
- Kaminariを用いたページネーション機能の実装（https://github.com/kaminari/kaminari）
- ページネーションのラベルの日本語化
 
### 目的
- 記事数が増えた場合でもユーザーが見やすくする為、またページの読み込み速度も考慮してページネーションを
追加しました。

<img width="321" alt="スクリーンショット 2025-02-04 17 29 08" src="https://github.com/user-attachments/assets/3908aa38-ac0c-4eb6-9324-8d6e9e8971bd" />