### PR TITLE
ユーザー新規作成機能の追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,22 @@
+class UsersController < ApplicationController
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+        session[:user_id] = @user.id
+        flash.now[:notice] = "ユーザーの新規登録に成功しました。"
+        redirect_to root_path
+    else
+        flash.now[:alert] = "ユーザーの新規登録に失敗しました。"
+        render :new
+    end
+  end
+
+  private
+  def user_params
+      params.require(:user).permit(:name, :email, :password)
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,5 @@
+class User < ApplicationRecord
+  validates :name, presence: true, length: {minimum:2, maximum:32}
+  validates :email, presence: true, uniqueness: true
+  validates :password, presence: true, format: {with: /^[0-9a-zA-Z]+$/, multiline: true}
+end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -10,3 +10,5 @@
 <%= paginate @articles %>
 
 <%= link_to "新規作成", new_article_path %>
+
+<%= link_to "新規登録", new_user_path %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,31 @@
+<h1>新規作成</h1>
+
+<%= form_with model: @user do |form| %>
+  <div>
+    <%= form.label "お名前" %><br>
+    <%= form.text_field :name%>
+    <% @user.errors.full_messages_for(:name).each do |message| %>
+      <div><%= message %></div>
+    <% end %>
+  </div>
+
+  <div>
+    <%= form.label "メールアドレス" %><br>
+    <%= form.text_field :email %>
+    <% @user.errors.full_messages_for(:email).each do |message| %>
+      <div><%= message %></div>
+    <% end %>
+  </div>
+
+  <div>
+    <%= form.label "パスワード" %><br>
+    <%= form.text_field :password %>
+    <% @user.errors.full_messages_for(:password).each do |message| %>
+      <div><%= message %></div>
+    <% end %>
+  </div>
+
+  <div>
+    <%= form.submit "新規登録"%>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,5 @@ Rails.application.routes.draw do
   # get "/articles/:id", to: "articles#show"
   resources :articles
 
-  delete 'articles/:id', to: 'articles#destroy'
+  resources :users
 end

--- a/db/migrate/20250205074409_create_users.rb
+++ b/db/migrate/20250205074409_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :users do |t|
+      t.string :name
+      t.string :email
+      t.string :password
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_29_121529) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_05_074409) do
   create_table "articles", force: :cascade do |t|
     t.string "title"
     t.text "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "password"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 概要
- ユーザー新規登録機能を追加しました。
 
### 変更内容
- ユーザー新規登録機能の実装
<img width="263" alt="スクリーンショット 2025-02-06 16 25 33" src="https://github.com/user-attachments/assets/b39f8057-b188-4822-b0cf-52cdc88f341e" />

- 記事一覧(トップページ)に新規作成リンクを追加
<img width="319" alt="スクリーンショット 2025-02-06 16 45 20" src="https://github.com/user-attachments/assets/966ad70f-5d92-4b1b-bbed-fbacbb802b79" />

### 目的
- 今後ログイン状態でのみ記事を投稿できたり、記事とユーザー情報を紐づけて記事に投稿者名を表示する為、ユーザーの新規登録を実装しました。
 
### 注意事項
- ユーザー新規登録画面から追加した情報が登録されていることをコンソール上で確認しました。
<img width="514" alt="スクリーンショット 2025-02-06 16 23 09" src="https://github.com/user-attachments/assets/e8cff54e-7644-4cd9-a4da-d30789022244" />

### タスク一覧
-----機能・コンポーネント作成——
✅記事投稿
✅記事一覧
✅個別記事
✅記事編集
✅記事削除
✅ページネーション
✅記事検索
✅ユーザー登録
◻️ユーザー切替
◻️ユーザー削除
◻️ユーザー情報更新
◻️ログイン
◻️ログアウト
◻️ユーザー別記事管理画面
◻️タグ
◻️いいね
◻️日付
◻️画像投稿
◻️ヘッダー + ナビゲーション
◻️フッター
◻️ログイン状態での記事投稿（記事へユーザー情報の付与）
◻️ログイン時とログアウト状態で記事一覧(トップページ)の表示を変える

——-見た目-----
◻️記事一覧(トップページ)
◻️個別記事
◻️記事編集
◻️記事削除
◻️ユーザー作成
◻️ユーザー情報更新
◻️ユーザー削除
◻️ログイン
◻️ログアウト
◻️ユーザー別記事管理画面