### PR TITLE
çの追加

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,4 +12,9 @@ class SessionsController < ApplicationController
       render "new", status: :unprocessable_entity
     end
   end
+
+  def destroy
+    log_out
+    redirect_to root_path
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -10,4 +10,9 @@ module SessionsHelper
   def logged_in?
     !current_user.nil?
   end
+
+  def log_out
+    session.delete(:user_id)
+    @current_user = nil
+  end
 end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,7 +1,11 @@
 <h1>RoRでブログを作成</h1>
 
-<%= link_to "ログイン", login_path %>
-<%= link_to "新規登録", new_user_path %>
+<% if logged_in? %>
+  <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete, turbo_confirm: " 本当にログアウトしますか？"} %>
+<% else %>
+  <%= link_to "ログイン", login_path %>
+  <%= link_to "新規登録", new_user_path %>
+<% end %>
 
 <%= form_tag(root_path,:method => 'get') do %>
   <%= text_field_tag :search %>


### PR DESCRIPTION
### 概要
- ログアウト機能を追加しました。
 
### 変更内容
- ログアウト機能の実装
ログイン状態でログアウトをクリックするとダイアログが表示され、OKするとログアウトできる

- ログインしていない状態では「ログイン」と「新規登録」が表示され
<img width="324" alt="スクリーンショット 2025-02-09 16 47 10" src="https://github.com/user-attachments/assets/eb058d1e-58e1-4218-aee2-392c7576fe07" />

ログイン状態では「ログアウト」が表示されるように実装した
<img width="324" alt="スクリーンショット 2025-02-09 16 48 29" src="https://github.com/user-attachments/assets/8965c285-ba4c-4dbe-ba3b-825976a564b0" />

 
### 目的
- ログアウトできるようにする為、またユーザーを切り替える際に一度ログアウトする必要がある為、ログアウト機能を実装した。

### タスク一覧
-----機能・コンポーネント作成——
✅記事投稿
✅記事一覧
✅個別記事
✅記事編集
✅記事削除
✅ページネーション
✅記事検索
✅ユーザー登録
◻️ユーザー削除
◻️ユーザー情報更新
✅ログイン
✅ログアウト
◻️ユーザー別記事管理画面
◻️タグ
◻️いいね
◻️日付
◻️画像投稿
◻️ヘッダー + ナビゲーション
◻️フッター
◻️ログイン状態での記事投稿（記事へユーザー情報の付与）
✅ログイン時とログアウト状態で記事一覧(トップページ)の表示を変える

——-見た目-----
◻️記事一覧(トップページ)
◻️個別記事
◻️記事編集
◻️記事削除
◻️ユーザー作成
◻️ユーザー情報更新
◻️ユーザー削除
◻️ログイン
◻️ログアウト
◻️ユーザー別記事管理画面