### PR TITLE
ログイン時のみ新規作成を表示

### DIFF
--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -25,6 +25,10 @@
   </p>
 <% end %>
 
+<% if logged_in? %>
+  <%= link_to "新規作成", new_article_path %>
+<% end %>
+
 <ul>
   <% @articles.each do |article| %>
     <li>
@@ -34,5 +38,3 @@
 </ul>
 
 <%= paginate @articles %>
-
-<%= link_to "新規作成", new_article_path %>


### PR DESCRIPTION
### 概要
- ログイン時のみ新規作成を表示するように変更しました。
 
### 変更内容
- ログイン時のみ新規作成が表示されるように変更
<img width="324" alt="スクリーンショット 2025-02-09 17 18 58" src="https://github.com/user-attachments/assets/03377b92-1ce6-40c0-8396-d06ff0fbf374" />

ログアウト時
<img width="323" alt="スクリーンショット 2025-02-09 17 19 35" src="https://github.com/user-attachments/assets/698a2fc0-0927-4678-9a62-04ddf57449b5" />

### 目的
- ログイン時のみ記事の投稿をできるようにする為（ログインしていない状態では閲覧のみにする）。