### PR TITLE
個別記事への作成者の表示

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,11 +1,6 @@
 class ArticlesController < ApplicationController
   def index
     @articles = Article.all.page(params[:page]).per(5)
-    if params[:search]
-      @articles = Article.search(params[:search]).page(params[:page]).per(5)
-    else
-      @articles = Article.all.page(params[:page]).per(5)
-    end
   end
 
   def show
@@ -17,8 +12,7 @@ class ArticlesController < ApplicationController
   end
 
   def create
-    @article = Article.new(article_params)
-
+    @article = current_user.articles.build(article_params)
     if @article.save
       redirect_to @article
     else
@@ -44,10 +38,6 @@ class ArticlesController < ApplicationController
     @article = Article.find(params[:id])
     @article.update(article_params)
     redirect_to @article
-  end
-
-  def search
-    @articles = Article.search(params[:search])
   end
 
   private

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,6 +1,9 @@
 class Article < ApplicationRecord
+  belongs_to :user
+
   validates :title, presence: true
   validates :body, presence: true, length: { minimum: 10 }
+  validates :user_id, presence: true
 
   def self.search(search)
     if search

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,8 @@
 class User < ApplicationRecord
+  has_many :articles
+
   has_secure_password
+
   validates :name, presence: true, length: {minimum:2, maximum:32}
   validates :email, presence: true, uniqueness: true
   validates :password, presence: true, format: {with: /^[0-9a-zA-Z]+$/, multiline: true}

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -2,6 +2,8 @@
 
 <p><%= @article.body %></p>
 
+<p>作成者：<%= @article.user.name %><p/>
+
 <%= link_to "編集", edit_article_path(@article) %>
 
 <%= link_to "削除", article_path(@article), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>

--- a/db/migrate/20250209083434_add_user_to_articles.rb
+++ b/db/migrate/20250209083434_add_user_to_articles.rb
@@ -1,0 +1,5 @@
+class AddUserToArticles < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :articles, :user, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_09_014021) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_09_083434) do
   create_table "articles", force: :cascade do |t|
     t.string "title"
     t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -26,4 +28,5 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_09_014021) do
     t.string "password_digest"
   end
 
+  add_foreign_key "articles", "users"
 end


### PR DESCRIPTION
### 概要
- 個別記事への作成者の表示をできるようにしました。
 
### 変更内容
- 個別記事における作成者の表示
<img width="324" alt="スクリーンショット 2025-02-09 18 08 42" src="https://github.com/user-attachments/assets/243b5b16-7083-4206-bea8-a03bd047a434" />
 
### 目的
- 記事の作成者を明確にする為。

### タスク一覧
-----機能・コンポーネント作成——
✅記事投稿
✅記事一覧
✅個別記事
✅記事編集
✅記事削除
✅ページネーション
✅記事検索
✅ユーザー登録
◻️ユーザー削除
◻️ユーザー情報更新
✅ログイン
✅ログアウト
◻️ユーザー別記事管理画面
◻️タグ
◻️いいね
◻️日付
◻️画像投稿
◻️ヘッダー + ナビゲーション
◻️フッター
✅ログイン状態での記事投稿（記事へユーザー情報の付与）
✅ログイン時とログアウト状態で記事一覧(トップページ)の表示を変える

——-見た目-----
◻️記事一覧(トップページ)
◻️個別記事
◻️記事編集
◻️記事削除
◻️ユーザー作成
◻️ユーザー情報更新
◻️ユーザー削除
◻️ログイン
◻️ログアウト
◻️ユーザー別記事管理画面