### PR TITLE
ユーザーアイコンの追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 gem "bootsnap", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 1.2"
 
 gem 'kaminari'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,10 +107,15 @@ GEM
     drb (2.2.1)
     error_highlight (0.7.0)
     erubi (1.13.1)
+    ffi (1.17.1-x86_64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    image_processing (1.14.0)
+      mini_magick (>= 4.9.5, < 6)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (2.1.0)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -146,6 +151,9 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mini_magick (5.1.2)
+      benchmark
+      logger
     mini_mime (1.1.5)
     minitest (5.25.4)
     msgpack (1.7.5)
@@ -218,6 +226,9 @@ GEM
     reline (0.6.0)
       io-console (~> 0.5)
     rexml (3.4.0)
+    ruby-vips (2.2.3)
+      ffi (~> 1.12)
+      logger
     rubyzip (2.4.1)
     securerandom (0.4.1)
     selenium-webdriver (4.28.0)
@@ -269,6 +280,7 @@ DEPENDENCIES
   capybara
   debug
   error_highlight (>= 0.4.0)
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
   kaminari

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -48,6 +48,12 @@
   padding-top: 2px;
  }
 
+ .avatar-image {
+  width: 35px;
+  height: 35px;
+  border-radius: 50%;
+ }
+
  .search-container {
   width: 100%;
   margin: 5px auto;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,9 +6,10 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-        flash.now[:notice] = "ユーザーの新規登録に成功しました。"
+        flash[:notice] = "ユーザーの新規登録に成功しました。"
         redirect_to root_path
     else
+        Rails.logger.debug("Validation errors: #{@user.errors.full_messages}")  # エラーメッセージをログに出力
         flash.now[:alert] = "ユーザーの新規登録に失敗しました。"
         render :new
     end
@@ -16,6 +17,6 @@ class UsersController < ApplicationController
 
   private
   def user_params
-      params.require(:user).permit(:name, :email, :password, :password_confirmation)
+      params.require(:user).permit(:name, :email, :password, :password_confirmation, :avatar)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,21 @@
 class User < ApplicationRecord
   has_many :articles
-
   has_secure_password
+  has_one_attached :avatar
+  validate :acceptable_avatar
+
+  def acceptable_avatar
+    return unless avatar.attached?
+
+    unless avatar.blob.byte_size <= 1.megabyte
+      errors.add(:avatar, "は1MB以下にしてください")
+    end
+
+    acceptable_types = ["image/jpeg", "image/png"]
+    unless acceptable_types.include?(avatar.content_type)
+      errors.add(:avatar, "はJPEGまたはPNG形式にしてください")
+    end
+  end
 
   validates :name, presence: true, length: {minimum:2, maximum:32}
   validates :email, presence: true, uniqueness: true

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -6,6 +6,9 @@
     <% if logged_in? %>
       <%= link_to "記事作成", new_article_path %>
       <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete, turbo_confirm: " 本当にログアウトしますか？"} %>
+      <% if current_user&.avatar&.attached? %>
+        <%= image_tag current_user.avatar, class: "avatar-image" %>
+      <% end %>
     <% else %>
       <%= link_to "ログイン", login_path %>
       <%= link_to "新規登録", new_user_path %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -26,6 +26,11 @@
   </div>
 
   <div>
+    <%= form.label "プロフィール画像" %><br>
+    <%= form.file_field :avatar, accept: 'image/jpeg,image/png' %>
+  </div>
+
+  <div>
     <%= form.submit "新規登録"%>
   </div>
 <% end %>

--- a/db/migrate/20250213121147_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20250213121147_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_09_083434) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_13_121147) do
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
   create_table "articles", force: :cascade do |t|
     t.string "title"
     t.text "body"
@@ -28,5 +56,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_09_083434) do
     t.string "password_digest"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "articles", "users"
 end


### PR DESCRIPTION
### 概要
- 新しい機能を追加しました。
 
### 変更内容
- １ユーザーあたり１つまでアイコン画像を設定できる機能を追加
- ログイン状態の時、画面上部右側にユーザーのアイコンを表示できるようにした
<img width="406" alt="スクリーンショット 2025-02-14 16 05 59" src="https://github.com/user-attachments/assets/69edbdfa-6711-4d3c-93a7-47c273eb5d74" />

### 目的
- UXの向上の為。