### PR TITLE
投稿一覧での投稿日の表示

### DIFF
--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -31,6 +31,7 @@
         </p>
         <div class="article-author">
           <p>作成者：<%= article.user.name %></p>
+          <p><%= article.created_at.strftime("%Y年%m月%d日")%></p>
           <p><%= render "favorites/btn", article: article %></p>
         </div>
       </div>


### PR DESCRIPTION
### 概要
- 投稿日の表示機能を追加しました。
 
### 変更内容
- 投稿一覧に各記事の投稿日時を追加しました
<img width="404" alt="スクリーンショット 2025-02-23 9 29 10" src="https://github.com/user-attachments/assets/4cbb938a-2b15-4d57-9ad0-b8ef146513a4" />

 
### 目的
ユーザーが記事を閲覧する際に投稿日を確認できるようにする為
